### PR TITLE
Scale down UI elements to 90% and fix mobile education toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,16 +60,16 @@ h2 {
 
 h2,
 h3 {
-  font-size: 20px;
+  font-size: 18px;
 }
 
 h1 {
   font-family: "Rubik", sans-serif;
-  font-size: 32px;
+  font-size: 29px;
 }
 
 p {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 300;
 }
 
@@ -82,30 +82,30 @@ p {
 
 @media (width >= 800px) {
   #root {
-    gap: 50px;
+    gap: 45px;
   }
   h1 {
-    font-size: 40px;
+    font-size: 36px;
   }
   h2,
   h3 {
-    font-size: 24px;
+    font-size: 22px;
   }
   p {
-    font-size: 20px;
+    font-size: 18px;
   }
   .sectionTitle {
-    margin-bottom: 60px;
+    margin-bottom: 54px;
   }
 }
 @media (width >= 1400px) {
   #root {
-    gap: 80px;
+    gap: 72px;
   }
   h1 {
-    font-size: 48px;
+    font-size: 43px;
   }
   .sectionTitle {
-    margin-bottom: 75px;
+    margin-bottom: 68px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -94,24 +94,24 @@ h6 {
 }
 
 h1 {
-  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-size: clamp(2.25rem, 4.5vw, 3.6rem);
   font-weight: 800;
   letter-spacing: -0.02em;
 }
 
 h2 {
-  font-size: clamp(2rem, 4vw, 3rem);
+  font-size: clamp(1.8rem, 3.6vw, 2.7rem);
   font-weight: 700;
   letter-spacing: -0.01em;
 }
 
 h3 {
-  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-size: clamp(1.35rem, 2.7vw, 1.8rem);
   font-weight: 600;
 }
 
 p {
-  font-size: clamp(1rem, 2vw, 1.125rem);
+  font-size: clamp(0.9rem, 1.8vw, 1.01rem);
   color: var(--text-secondary);
   line-height: 1.7;
 }

--- a/src/section/Education/EducationGlass.jsx
+++ b/src/section/Education/EducationGlass.jsx
@@ -72,7 +72,9 @@ const EducationGlass = () => {
             <span>Work Experience</span>
           </button>
           <div
-            className={styles.activeIndicator}
+            className={`${styles.activeIndicator} ${
+              activeTab === "work" ? styles.indicatorWork : ""
+            }`}
             style={{
               transform:
                 activeTab === "education"

--- a/src/section/Education/EducationGlass.module.css
+++ b/src/section/Education/EducationGlass.module.css
@@ -407,16 +407,15 @@
 
   .activeIndicator {
     width: calc(100% - 1rem);
-    height: auto;
+    height: calc(50% - 0.5rem);
+    top: 0.5rem;
+    left: 0.5rem;
+    transition: transform 0.3s ease;
     transform: translateY(0) !important;
   }
 
-  .activeIndicator[style*="translateX(0)"] {
-    transform: translateY(0) !important;
-  }
-
-  .activeIndicator[style*="translateX(100%)"] {
-    transform: translateY(calc(100% + 0.5rem)) !important;
+  .activeIndicator.indicatorWork {
+    transform: translateY(calc(100% + 0.25rem)) !important;
   }
 
   .cardGlass {

--- a/src/section/Hero/HeroGlass.module.css
+++ b/src/section/Hero/HeroGlass.module.css
@@ -200,9 +200,9 @@
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 4rem;
+  gap: 3.6rem;
   align-items: center;
-  padding: 0 2rem;
+  padding: 0 1.8rem;
 }
 
 /* Glass Card for Content */
@@ -210,15 +210,15 @@
   background: rgba(var(--glass-bg-rgb), 0.4);
   backdrop-filter: blur(40px) saturate(180%);
   -webkit-backdrop-filter: blur(40px) saturate(180%);
-  border-radius: 32px;
+  border-radius: 29px;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  padding: 3rem 3.5rem;
+  padding: 2.7rem 3.15rem;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12),
     0 0 0 1px rgba(255, 255, 255, 0.05) inset,
     0 1px 0 rgba(255, 255, 255, 0.2) inset;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.8rem;
   animation: fadeIn 1s ease-out;
   position: relative;
   overflow: visible;
@@ -243,14 +243,14 @@
 .statusBadge {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.25rem;
+  gap: 0.45rem;
+  padding: 0.675rem 1.125rem;
   background: rgba(var(--bubble-color-rgb), 0.15);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(var(--bubble-color-rgb), 0.3);
   border-radius: 100px;
-  font-size: 0.875rem;
+  font-size: 0.79rem;
   font-weight: 600;
   color: var(--text-color);
   width: fit-content;
@@ -277,7 +277,7 @@
 
 .greeting {
   font-family: "Fira Sans", sans-serif;
-  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-size: clamp(1.35rem, 2.7vw, 1.8rem);
   font-weight: 400;
   color: var(--text-color);
   opacity: 0.7;
@@ -285,7 +285,7 @@
 
 .name {
   font-family: "Rubik", sans-serif;
-  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-size: clamp(2.25rem, 5.4vw, 4.05rem);
   font-weight: 800;
   background: linear-gradient(
     90deg,
@@ -308,7 +308,7 @@
 
 /* Role Container */
 .roleContainer {
-  height: 60px;
+  height: 54px;
   overflow: hidden;
   position: relative;
 }
@@ -320,7 +320,7 @@
 
 .role {
   font-family: "Fira Sans", sans-serif;
-  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-size: clamp(1.35rem, 3.6vw, 2.25rem);
   font-weight: 600;
   color: var(--btn-hover-color);
   margin: 0;
@@ -339,7 +339,7 @@
 /* Description */
 .description {
   font-family: "Fira Sans", sans-serif;
-  font-size: clamp(1rem, 2vw, 1.125rem);
+  font-size: clamp(0.9rem, 1.8vw, 1.01rem);
   line-height: 1.7;
   color: var(--text-color);
   opacity: 0.8;
@@ -349,16 +349,16 @@
 /* Glass Buttons */
 .actions {
   display: flex;
-  gap: 1rem;
+  gap: 0.9rem;
   flex-wrap: wrap;
 }
 
 .glassBtnPrimary,
 .glassBtnSecondary {
   position: relative;
-  padding: 1rem 2rem;
-  border-radius: 16px;
-  font-size: 1rem;
+  padding: 0.9rem 1.8rem;
+  border-radius: 14px;
+  font-size: 0.9rem;
   font-weight: 600;
   text-decoration: none;
   font-family: "Fira Sans", sans-serif;

--- a/src/section/Navbar/NavbarGlass.module.css
+++ b/src/section/Navbar/NavbarGlass.module.css
@@ -35,7 +35,7 @@
   left: 0;
   right: 0;
   z-index: 1000;
-  padding: 1rem 2rem;
+  padding: 0.9rem 1.8rem;
   transition: all 0.3s ease;
   animation: slideDown 0.6s ease-out;
 }
@@ -52,13 +52,13 @@
 
 /* Nav Content */
 .navContent {
-  max-width: 1400px;
+  max-width: 1260px;
   margin: 0 auto;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1.5rem;
-  border-radius: 20px;
+  padding: 0.675rem 1.35rem;
+  border-radius: 18px;
   background: transparent;
   transition: all 0.3s ease;
   position: relative;
@@ -91,8 +91,8 @@
 }
 
 .logoGlass {
-  width: 48px;
-  height: 48px;
+  width: 43px;
+  height: 43px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -100,7 +100,7 @@
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 12px;
+  border-radius: 11px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15),
     inset 0 0 0 1px rgba(255, 255, 255, 0.1),
     inset 0 1px 0 rgba(255, 255, 255, 0.2);
@@ -132,7 +132,7 @@
 
 .logoText {
   font-family: "Rubik", sans-serif;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
   font-weight: 800;
   color: var(--btn-text-color-hover);
   letter-spacing: 1px;
@@ -141,7 +141,7 @@
 /* Nav Links */
 .navLinks {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.675rem;
   align-items: center;
 }
 
@@ -153,14 +153,14 @@
 .linkGlass {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.25rem;
+  gap: 0.45rem;
+  padding: 0.56rem 1.125rem;
   background: rgba(var(--glass-bg-rgb), 0.3);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 12px;
-  font-size: 0.938rem;
+  border-radius: 11px;
+  font-size: 0.844rem;
   font-weight: 600;
   color: var(--text-color);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08),
@@ -206,7 +206,7 @@
 .rightSection {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.675rem;
 }
 
 /* Theme Toggle */
@@ -218,8 +218,8 @@
 }
 
 .toggleGlass {
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -227,7 +227,7 @@
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 12px;
+  border-radius: 11px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1),
     inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   transition: all 0.3s ease;
@@ -264,8 +264,8 @@
 }
 
 .toggleGlass img {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 }


### PR DESCRIPTION
- Reduce global font sizes, padding, and spacing to 90% of original
- Scale down Hero section glass cards, buttons, and typography
- Scale down Navbar logo, links, and toggle buttons
- Fix education/work toggle indicator on mobile layout
- Use CSS class instead of attribute selector for reliable mobile toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)